### PR TITLE
モーダルヘッダー実装

### DIFF
--- a/frontend/react/src/App.tsx
+++ b/frontend/react/src/App.tsx
@@ -3,10 +3,12 @@ import "./App.css";
 import { BrowserRouter as Router } from "react-router-dom";
 
 import AppRoutes from "./routes";
+import Header from "./pages/header/coomponents/templates/Header";
 
 const App: React.FC = () => {
   return (
     <Router>
+      <Header />
       <AppRoutes />
     </Router>
   );

--- a/frontend/react/src/components/molecules/modal/AddModal.tsx
+++ b/frontend/react/src/components/molecules/modal/AddModal.tsx
@@ -11,6 +11,7 @@ type AddModalProps = {
   data: MemberData;
   onClose: () => void;
   index: number;
+  columns: string[];
 };
 
 /**
@@ -20,9 +21,10 @@ type AddModalProps = {
  * @param {MemberData} props.data - 対象のデータ。
  * @param {function} props.onClose - 追加モーダルを閉じる関数。
  * @param {number} props.index - 選択行。
+ * @param {string[]} props.columns - モーダルのヘッダー項目データ
  * @returns {JSX.Element} 追加モーダルを返します。
  */
-const AddModal: React.FC<AddModalProps> = ({ data, onClose, index }) => {
+const AddModal: React.FC<AddModalProps> = ({ data, onClose, index, columns }) => {
   const [formData, setFormData] = useState(data);
 
   const handleValueChange = (field: string, value: string | number) => {
@@ -45,7 +47,7 @@ const AddModal: React.FC<AddModalProps> = ({ data, onClose, index }) => {
       <div className="mx-5 grid shadow-lg rounded-lg overflow-hidden">
         <table className="min-w-full border-collapse">
           <thead>
-            <TableHeader isShowing={false} />
+            <TableHeader columns={columns} />
           </thead>
           <tbody>
             <AddTableRow

--- a/frontend/react/src/components/molecules/modal/DeleteModal.tsx
+++ b/frontend/react/src/components/molecules/modal/DeleteModal.tsx
@@ -10,6 +10,7 @@ import TableHeader from "../TableHeader";
 type MemberTableProps = {
   onClose: () => void;
   data: MemberData;
+  columns: string[]
 };
 
 /**
@@ -19,10 +20,11 @@ type MemberTableProps = {
  * @param {MemberTableProps} props - 削除モーダルのプロパティ。
  * @param {() => void} props.onClose - モーダルを閉じるための関数。
  * @param {MemberData} props.data - 削除対象のメンバーのデータ。
+ * @param {string[]} props.columns - モーダルのヘッダー項目データ
  * @returns {JSX.Element} メンバー削除用のモーダルコンポーネントを返します。
  */
 
-const DeleteModal: React.FC<MemberTableProps> = ({ onClose, data }) => {
+const DeleteModal: React.FC<MemberTableProps> = ({ onClose, data, columns }) => {
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-gray-800 bg-opacity-50 z-50">
       <div className="bg-white shadow-lg rounded-lg p-6 w-full max-w-3xl mx-auto">
@@ -38,7 +40,7 @@ const DeleteModal: React.FC<MemberTableProps> = ({ onClose, data }) => {
           <div className="bg-white shadow-md rounded-lg overflow-hidden">
             <table className="min-w-full border-collapse">
               <thead>
-                <TableHeader isShowing={false} />
+                <TableHeader columns={columns} />
               </thead>
               <tbody className="bg-customPurple">
                 <TableRowColumn width="5%">{data.id}</TableRowColumn>

--- a/frontend/react/src/components/molecules/modal/EditModal.tsx
+++ b/frontend/react/src/components/molecules/modal/EditModal.tsx
@@ -10,6 +10,7 @@ import TableHeader from "../TableHeader";
 type MemberTableProps = {
   onClose: () => void;
   data: MemberData;
+  columns: string[];
 };
 
 /**
@@ -19,9 +20,10 @@ type MemberTableProps = {
  * @param {MemberTableProps} props - 編集モーダルのプロパティ。
  * @param {() => void} props.onClose - モーダルを閉じるための関数。
  * @param {MemberData} props.data - 編集対象のメンバーのデータ。
+ * @param {string[]} props.columns - モーダルのヘッダー項目データ
  * @returns {JSX.Element} メンバー編集用のモーダルコンポーネントを返します。
  */
-const EditModal: React.FC<MemberTableProps> = ({ onClose, data }) => {
+const EditModal: React.FC<MemberTableProps> = ({ onClose, data, columns }) => {
   const [EditData, setEditData] = useState(data);
 
   /**
@@ -45,7 +47,7 @@ const EditModal: React.FC<MemberTableProps> = ({ onClose, data }) => {
       <div className="mx-5 grid shadow-lg rounded-lg overflow-hidden">
         <table className="min-w-full border-collapse">
           <thead>
-            <TableHeader isShowing={false} />
+            <TableHeader columns={columns}/>
           </thead>
           <tbody>
             <EditTableRow

--- a/frontend/react/src/pages/memberManagement/components/templates/MemberTable.tsx
+++ b/frontend/react/src/pages/memberManagement/components/templates/MemberTable.tsx
@@ -9,7 +9,6 @@ import TableRow from "../../../../components/molecules/row/TableRow";
 import SearchBar from "../../../../components/molecules/SearchBar";
 import TableHeader from "../../../../components/molecules/TableHeader";
 import { MemberTableProps } from "../../../../types/member";
-import Header from "../../../header/coomponents/templates/Header";
 /**
  * メンバーの一覧を表示し、追加・編集・削除を行うテーブルコンポーネント。
  *
@@ -28,6 +27,7 @@ const MemberTable: React.FC<MemberTableProps> = ({ data }) => {
   };
 
   const columns = ["ID", "メンバー名", "等級", "原価", "開始日", "操作"];
+  const modalColumns = ["ID", "メンバー名", "等級", "原価", "開始日"];
 
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -112,7 +112,6 @@ const MemberTable: React.FC<MemberTableProps> = ({ data }) => {
 
   return (
     <>
-      <Header />
       <div className="shadow-lg rounded-lg overflow-hidden p-8">
         <SearchBar
           searchValue={searchValue}
@@ -155,6 +154,7 @@ const MemberTable: React.FC<MemberTableProps> = ({ data }) => {
               onClose={handleCloseAddModal}
               data={initialFormData}
               index={data.length}
+              columns={modalColumns}
             />
           </div>
         </div>
@@ -163,7 +163,7 @@ const MemberTable: React.FC<MemberTableProps> = ({ data }) => {
         <div className="fixed inset-0 flex items-center justify-center z-50">
           <div className="absolute inset-0 bg-black opacity-50"></div>
           <div className="relative bg-white rounded-lg p-8 shadow-lg z-10">
-            <EditModal onClose={handleCloseEditModal} data={editData} />
+            <EditModal onClose={handleCloseEditModal} data={editData} columns={modalColumns}/>
           </div>
         </div>
       )}
@@ -171,7 +171,7 @@ const MemberTable: React.FC<MemberTableProps> = ({ data }) => {
         <div className="fixed inset-0 flex items-center justify-center z-50">
           <div className="absolute inset-0 bg-black opacity-50"></div>
           <div className="relative bg-white rounded-lg p-8 shadow-lg z-10">
-            <DeleteModal onClose={handleCloseDeleteModal} data={deleteData} />
+            <DeleteModal onClose={handleCloseDeleteModal} data={deleteData} columns={modalColumns} />
           </div>
         </div>
       )}

--- a/frontend/react/src/pages/projectManagement/components/molecules/modal/DeleteModal.tsx
+++ b/frontend/react/src/pages/projectManagement/components/molecules/modal/DeleteModal.tsx
@@ -11,6 +11,7 @@ import { ProjectData } from "../../../../../types/project";
 type ProjectManagementProps = {
   onClose: () => void;
   data: ProjectData;
+  columns: string[];
 };
 
 /**
@@ -20,10 +21,11 @@ type ProjectManagementProps = {
  * @param {ProjectManagementProps} props - 削除モーダルのプロパティ。
  * @param {() => void} props.onClose - モーダルを閉じるための関数。
  * @param {MemberData} props.data - 削除対象のメンバーのデータ。
+ * @param {string[]} props.columns - モーダルのヘッダー項目データ
  * @returns {JSX.Element} メンバー削除用のモーダルコンポーネントを返します。
  */
 
-const DeleteModal: React.FC<ProjectManagementProps> = ({ onClose, data }) => {
+const DeleteModal: React.FC<ProjectManagementProps> = ({ onClose, data, columns }) => {
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-gray-800 bg-opacity-50 z-50">
       <div className="bg-white shadow-lg rounded-lg p-6 w-full max-w-3xl mx-auto">
@@ -39,7 +41,7 @@ const DeleteModal: React.FC<ProjectManagementProps> = ({ onClose, data }) => {
           <div className="bg-white shadow-md rounded-lg overflow-hidden">
             <table className="min-w-full border-collapse">
               <thead>
-                <TableHeader />
+                <TableHeader columns={columns}/>
               </thead>
               <tbody className="bg-customPurple">
                 <TableRowColumn width="5%">{data.id}</TableRowColumn>

--- a/frontend/react/src/pages/projectManagement/components/templates/ProjectManagement.tsx
+++ b/frontend/react/src/pages/projectManagement/components/templates/ProjectManagement.tsx
@@ -17,7 +17,8 @@ import TableRow from "../molecules/row/TableRow";
  * @returns {JSX.Element} ProjectManagementコンポーネントを返します。
  */
 const ProjectManagement: React.FC<ProjectDataProps> = ({ data }) => {
-  const columns = ["案件ID", "案件名", "期間", "PM", ""];
+  const columns = ["案件ID", "案件名", "期間", "PM", "操作"];
+  const modalColumns = ["案件ID", "案件名", "期間", "PM"]
   // TODO PMの中身実装
   const [showData, setShowData] = useState(data);
   const [searchValue, setSearchValue] = useState("");
@@ -116,7 +117,7 @@ const ProjectManagement: React.FC<ProjectDataProps> = ({ data }) => {
         <div className="fixed inset-0 flex items-center justify-center z-50">
           <div className="absolute inset-0 bg-black opacity-50"></div>
           <div className="relative bg-white rounded-lg p-8 shadow-lg z-10">
-            <DeleteModal onClose={handleCloseDeleteModal} data={deleteData} />
+            <DeleteModal onClose={handleCloseDeleteModal} data={deleteData} columns={modalColumns}/>
           </div>
         </div>
       )}


### PR DESCRIPTION
[本チケット](https://github.com/RyosukeSakakibara718/project-balancer/issues/155)ではメンバー管理画面のみを対象としていましたが、現在着手できた他の画面も対応したしました。
また、合わせてヘッダーを全画面に表示できるように修正いたしました。